### PR TITLE
ksidirop/NTOP 0053 flag to display raw bytes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ _testmain.go
 
 /dist
 /nats-top
+
+# VSCode
+
+.vscode/**
+*.code-workspace

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ and releases of the binary are also [available](https://github.com/nats-io/nats-
 
 ```
 usage: nats-top [-s server] [-m http_port] [-ms https_port] [-n num_connections] [-d delay_secs] [-sort by]
-                [-cert FILE] [-key FILE ][-cacert FILE] [-k]
+                [-cert FILE] [-key FILE ][-cacert FILE] [-k] [-b]
 ```
 
 - `-m http_port`, `-ms https_port`
@@ -67,6 +67,10 @@ usage: nats-top [-s server] [-m http_port] [-ms https_port] [-n num_connections]
 - `-k`
 
   Configure to skip verification of certificate.
+
+- `-b`
+
+  Displays traffic in raw bytes.
 
 ## Commands
 

--- a/util/toputils.go
+++ b/util/toputils.go
@@ -259,13 +259,15 @@ func Psize(s int64) string {
 
 	if size < kibibyte {
 		return fmt.Sprintf("%.0f", size)
-	} else if size < mebibyte {
-		return fmt.Sprintf("%.1fK", size/kibibyte)
-	} else if size < gibibyte {
-		return fmt.Sprintf("%.1fM", size/mebibyte)
-	} else if size >= gibibyte {
-		return fmt.Sprintf("%.1fG", size/gibibyte)
-	} else {
-		return "NA"
 	}
+
+	if size < mebibyte {
+		return fmt.Sprintf("%.1fK", size/kibibyte)
+	}
+
+	if size < gibibyte {
+		return fmt.Sprintf("%.1fM", size/mebibyte)
+	}
+
+	return fmt.Sprintf("%.1fG", size/gibibyte)
 }

--- a/util/toputils.go
+++ b/util/toputils.go
@@ -249,18 +249,22 @@ type Rates struct {
 	OutBytesRate float64
 }
 
+const kibibyte = 1024
+const mebibyte = 1024 * 1024
+const gibibyte = 1024 * 1024 * 1024
+
 // Psize takes a float and returns a human readable string.
 func Psize(s int64) string {
 	size := float64(s)
 
-	if size < 1024 {
+	if size < kibibyte {
 		return fmt.Sprintf("%.0f", size)
-	} else if size < (1024 * 1024) {
-		return fmt.Sprintf("%.1fK", size/1024)
-	} else if size < (1024 * 1024 * 1024) {
-		return fmt.Sprintf("%.1fM", size/1024/1024)
-	} else if size >= (1024 * 1024 * 1024) {
-		return fmt.Sprintf("%.1fG", size/1024/1024/1024)
+	} else if size < mebibyte {
+		return fmt.Sprintf("%.1fK", size/kibibyte)
+	} else if size < gibibyte {
+		return fmt.Sprintf("%.1fM", size/mebibyte)
+	} else if size >= gibibyte {
+		return fmt.Sprintf("%.1fG", size/gibibyte)
 	} else {
 		return "NA"
 	}

--- a/util/toputils.go
+++ b/util/toputils.go
@@ -254,10 +254,10 @@ const mebibyte = 1024 * 1024
 const gibibyte = 1024 * 1024 * 1024
 
 // Psize takes a float and returns a human readable string.
-func Psize(s int64) string {
+func Psize(displayRawValue bool, s int64) string {
 	size := float64(s)
 
-	if size < kibibyte {
+	if displayRawValue || size < kibibyte {
 		return fmt.Sprintf("%.0f", size)
 	}
 

--- a/util/toputils_test.go
+++ b/util/toputils_test.go
@@ -102,25 +102,49 @@ func TestFetchingStatz(t *testing.T) {
 func TestPsize(t *testing.T) {
 
 	expected := "1023"
-	got := Psize(1023)
+	got := Psize(false, 1023)
 	if got != expected {
 		t.Fatalf("Wrong human readable value. expected: %v, got: %v", expected, got)
 	}
 
 	expected = "1.0K"
-	got = Psize(1024)
+	got = Psize(false, kibibyte)
 	if got != expected {
 		t.Fatalf("Wrong human readable value. expected: %v, got: %v", expected, got)
 	}
 
 	expected = "1.0M"
-	got = Psize(1024 * 1024)
+	got = Psize(false, mebibyte)
 	if got != expected {
 		t.Fatalf("Wrong human readable value. expected: %v, got: %v", expected, got)
 	}
 
 	expected = "1.0G"
-	got = Psize(1024 * 1024 * 1024)
+	got = Psize(false, gibibyte)
+	if got != expected {
+		t.Fatalf("Wrong human readable value. expected: %v, got: %v", expected, got)
+	}
+
+	expected = "1023"
+	got = Psize(true, 1023)
+	if got != expected {
+		t.Fatalf("Wrong human readable value. expected: %v, got: %v", expected, got)
+	}
+
+	expected = fmt.Sprintf("%d", kibibyte)
+	got = Psize(true, kibibyte)
+	if got != expected {
+		t.Fatalf("Wrong human readable value. expected: %v, got: %v", expected, got)
+	}
+
+	expected = fmt.Sprintf("%d", mebibyte)
+	got = Psize(true, mebibyte)
+	if got != expected {
+		t.Fatalf("Wrong human readable value. expected: %v, got: %v", expected, got)
+	}
+
+	expected = fmt.Sprintf("%d", gibibyte)
+	got = Psize(true, gibibyte)
 	if got != expected {
 		t.Fatalf("Wrong human readable value. expected: %v, got: %v", expected, got)
 	}


### PR DESCRIPTION
- chore (.gitignore): ignore .vscode folder and any *.code-workspace files
- clean (toputils.go): consolidate 1024-related constants used in Psize() into kibibytes, mebibytes, kibibytes which are well-known, human-readable units of measurement
- clean (toputils.go): neutral cleanups in Psize() to make it more readable
- feat (cli flags): add new flag '-b' which causes all traffic to be printed in raw bytes
